### PR TITLE
Add missing dependency for running tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
     "ember-disable-proxy-controllers": "^1.0.1",
     "ember-export-application-global": "^1.0.4",
     "ember-resolver": "^2.0.3",
-    "ember-try": "~0.0.8"
+    "ember-try": "~0.0.8",
+    "phantomjs": "^2.1.3"
   },
   "keywords": [
     "ember-addon",


### PR DESCRIPTION
After cloning the repo, `npm install`ing, `bower install`ing, then running `ember test`, you see an error message complaining about the absence of the Phantom JS runner. 