### PR TITLE
suggested resolution for deprecation causes 2 tests to fail

### DIFF
--- a/addon/components/dynamic-form.js
+++ b/addon/components/dynamic-form.js
@@ -76,7 +76,7 @@ const DynamicForm = Ember.Component.extend({
     const replaceWithFunction = function (object, value, key) {
       if (TYPE_MAP.hasOwnProperty(key) && typeof value === 'string') {
         const type = TYPE_MAP[key];
-        const typeObj = getOwner(this).lookup(`${value}:${type.namespace}`);
+        const typeObj = container.lookup(`${value}:${type.namespace}`);
         if (typeObj) {
           object[key] = typeObj[type.functionName];
         } // else fail with a message that the given type couldn't be found

--- a/addon/components/dynamic-form.js
+++ b/addon/components/dynamic-form.js
@@ -1,4 +1,5 @@
 import Ember from 'ember';
+import getOwner from 'ember-getowner-polyfill';
 
 const TYPE_MAP = {
   validator: {
@@ -44,7 +45,7 @@ const DynamicForm = Ember.Component.extend({
     const newSchema = _.reduce(optionFields, (result, val, key) => {
       if(val['filter-rules']) {
         val['filter-rules'].forEach((element) => {
-          const filterRule = this.container.lookup(`${element}:dynamic-forms.filter-rules`);
+          const filterRule = getOwner(this).lookup(`${element}:dynamic-forms.filter-rules`);
           filterRule.filter(key, result);
         });
       }
@@ -71,11 +72,11 @@ const DynamicForm = Ember.Component.extend({
   },
 
   _replaceKeywordsWithFunctions(schemaObj) {
-    const container = this.container;
+    const container = getOwner(this);
     const replaceWithFunction = function (object, value, key) {
       if (TYPE_MAP.hasOwnProperty(key) && typeof value === 'string') {
         const type = TYPE_MAP[key];
-        const typeObj = container.lookup(`${value}:${type.namespace}`);
+        const typeObj = getOwner(this).lookup(`${value}:${type.namespace}`);
         if (typeObj) {
           object[key] = typeObj[type.functionName];
         } // else fail with a message that the given type couldn't be found

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "ember-disable-prototype-extensions": "^1.0.0",
     "ember-disable-proxy-controllers": "^1.0.1",
     "ember-export-application-global": "^1.0.4",
+    "ember-getowner-polyfill": "1.0.0",
     "ember-resolver": "^2.0.3",
     "ember-try": "~0.0.8"
   },


### PR DESCRIPTION
Integration | Component | dynamic-form:formatters: applies a custom formatter when the user tabs away from the drinking age field (1, 0, 1)
Source: 	
TypeError: Cannot read property 'OWNER [id=__ember1454799682462811096802955]' of undefined
    at Object.getOwner (http://localhost:7357/assets/vendor.js:12234:18)
    at exports.default (http://localhost:7357/assets/vendor.js:130774:33)
    at replaceWithFunction (http://localhost:7357/assets/vendor.js:115675:63)
    at http://localhost:7357/assets/vendor.js:112602:16
    at http://localhost:7357/assets/vendor.js:105641:15
    at baseForOwn (http://localhost:7357/assets/vendor.js:104614:14)
    at Function.transform (http://localhost:7357/assets/vendor.js:112601:39)
    at replaceWithFunction (http://localhost:7357/assets/vendor.js:115680:29)
    at http://localhost:7357/assets/vendor.js:112602:16
    at http://localhost:7357/assets/vendor.js:105641:15

Integration | Component | dynamic-form:validations: should replace validator string with corresponding function (1, 0, 1)