### PR TITLE
Add the ability to disable the inclusion of certain assets.

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,18 @@ For more details component usage and asset generation, see the [ember-cli-dynami
 
 The schema variable can be in string or object form, but needs to be a valid json-schema alpaca form definition. See the [alpacajs website](http://alpacajs.org) for more information about building valid schemas.
 
+## Excluding Assets
+By default ember-cli-dynamic-forms imports bootstrap and alpaca assets to the broccoli tree. If you wish to disable this behaviour and use your own assets, simply specify it in your ember-cli-build.js.
+ 
+```js
+var app = new EmberApp({
+  'ember-cli-dynamic-forms': {
+    includeAssets: false, // disables the includion of all assets
+    includeBootstrapAssets: false // disables just the inclusion of bootstrap assets whilst leaving the rest inplace
+  }
+});
+```
+
 ## Development
 
 ### Setup

--- a/index.js
+++ b/index.js
@@ -5,29 +5,41 @@ module.exports = {
   name: 'ember-cli-dynamic-forms',
   included: function (app) {
     this._super.included(app);
+
+    app.options = app.options || {}; // ensure options is actually set to prevent undefined errors
+    var options = app.options['ember-cli-dynamic-forms'] || {}; // ensure we have an options object at the very least
+
+    // opt out early if we don't want any assets
+    if('includeAssets' in options && !options.includeAssets) {
+      return;
+    }
+
     app.import(app.bowerDirectory + '/handlebars/handlebars.js');
-    app.import(app.bowerDirectory + '/bootstrap/dist/js/bootstrap.js');
-    app.import(app.bowerDirectory + '/bootstrap/dist/css/bootstrap.css');
-    app.import('bower_components/bootstrap/dist/fonts/glyphicons-halflings-regular.woff', {
-      destDir: 'fonts'
-    });
-    app.import('bower_components/bootstrap/dist/fonts/glyphicons-halflings-regular.eot', {
-      destDir: 'fonts'
-    });
-    app.import('bower_components/bootstrap/dist/fonts/glyphicons-halflings-regular.svg', {
-      destDir: 'fonts'
-    });
-    app.import('bower_components/bootstrap/dist/fonts/glyphicons-halflings-regular.ttf', {
-      destDir: 'fonts'
-    });
-    app.import('bower_components/bootstrap/dist/fonts/glyphicons-halflings-regular.woff2', {
-      destDir: 'fonts'
-    });
+
+    // include bootstrap assets unless explicitly told otherwise
+    if(!('includeBootstrapAssets' in options) || options.includeBootstrapAssets) {
+      app.import(app.bowerDirectory + '/bootstrap/dist/js/bootstrap.js');
+      app.import(app.bowerDirectory + '/bootstrap/dist/css/bootstrap.css');
+      app.import('bower_components/bootstrap/dist/fonts/glyphicons-halflings-regular.woff', {
+        destDir: 'fonts'
+      });
+      app.import('bower_components/bootstrap/dist/fonts/glyphicons-halflings-regular.eot', {
+        destDir: 'fonts'
+      });
+      app.import('bower_components/bootstrap/dist/fonts/glyphicons-halflings-regular.svg', {
+        destDir: 'fonts'
+      });
+      app.import('bower_components/bootstrap/dist/fonts/glyphicons-halflings-regular.ttf', {
+        destDir: 'fonts'
+      });
+      app.import('bower_components/bootstrap/dist/fonts/glyphicons-halflings-regular.woff2', {
+        destDir: 'fonts'
+      });
+    }
 
     app.import(app.bowerDirectory + '/alpaca/dist/alpaca/bootstrap/alpaca.js');
     app.import(app.bowerDirectory + '/alpaca/dist/alpaca/bootstrap/alpaca.css');
     app.import(app.bowerDirectory + '/lodash/lodash.js');
-
 
   },
   isDevelopingAddon: function () {


### PR DESCRIPTION
Hit a problem with the bootstrap assets that are included causing an issue with another CSS framework (namely foundation). Added some config options that can be set in each apps ember-cli-build.js to control this behaviour.