### PR TITLE
Removing getOwner Polyfill since is deprecated since Ember 2.3

### DIFF
--- a/addon/components/dynamic-form.js
+++ b/addon/components/dynamic-form.js
@@ -1,6 +1,5 @@
 import Ember from 'ember';
-import getOwner from 'ember-getowner-polyfill';
-const { set, get } = Ember;
+const { set, get, getOwner } = Ember;
 
 const TYPE_MAP = {
   validator: {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "ember-data": "^2.8.0",
     "ember-disable-prototype-extensions": "^1.1.0",
     "ember-export-application-global": "^1.0.5",
-    "ember-getowner-polyfill": "1.0.0",
     "ember-load-initializers": "^0.5.1",
     "ember-resolver": "^2.0.3",
     "loader.js": "^4.0.1"


### PR DESCRIPTION
When trying to test this addon I ran into an issue of the _ember-getowner-polyfill_ module not being found. This polyfill is deprecated so here's a pr removing it from package.json and updating dynamic-forms.js.

cheers