### PR TITLE
remove 1.13 from ember-try

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ cache:
 
 env:
   - EMBER_TRY_SCENARIO=default
-  - EMBER_TRY_SCENARIO=ember-1.13
   - EMBER_TRY_SCENARIO=ember-release
   - EMBER_TRY_SCENARIO=ember-beta
   - EMBER_TRY_SCENARIO=ember-canary

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -8,17 +8,6 @@ module.exports = {
       }
     },
     {
-      name: 'ember-1.13',
-      bower: {
-        dependencies: {
-          'ember': '~1.13.0'
-        },
-        resolutions: {
-          'ember': '~1.13.0'
-        }
-      }
-    },
-    {
       name: 'ember-release',
       bower: {
         dependencies: {


### PR DESCRIPTION
now that we are at almost 2.11 and well beyond LTS support for 1.13, we are running into deprecations such as using the getOwner polyfill, that don't work on the latest versions.  Therefore, Taking 1.13 off ember try, and will support back to the last LTS, 2.8.3.